### PR TITLE
terraform-aws-provider v2.0 support updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     working_directory: ~/repo
 
     docker:
-      - image: unifio/ci:3.0.411-ruby-2.4
+      - image: unifio/ci:3.0.622-ruby-2.5.3
 
     environment:
       AWS_REGION: 'us-east-2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 #### IMPROVEMENTS / NEW FEATURES:
 * Add support for application auto scaling
 
+## 0.3.3 (March 10, 2019)
+
+#### BACKWARDS INCOMPATIBILITIES / NOTES:
+##### [terraform-provider-aws v2.0](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md) Updates
+* The [terraform-provider-aws](https://github.com/terraform-providers/terraform-provider-aws/issues/7697) has deprecated the use of the `current` filter in regions. The `current` filter was removed for [issue#7](https://github.com/unifio/terraform-aws-ecs/issues/8).
+* The [terraform-provider-aws](https://github.com/terraform-providers/terraform-provider-aws/issues/5576) now requires an `owners` argument. This was added in place of the owner-alias for [issue#8](https://github.com/unifio/terraform-aws-ecs/issues/8)
+* Updated [terraform-aws-asg](https://github.com/unifio/terraform-aws-asg/releases/tag/v0.3.7) to v0.3.7
+
 ## 0.3.2 (March 9, 2018)
 
 #### BACKWARDS INCOMPATIBILITIES / NOTES:

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -5,9 +5,7 @@ terraform {
   required_version = "> 0.11.0"
 }
 
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 ## Creates cloud-config data for agent cluster
 data "template_file" "user_data" {
@@ -22,6 +20,7 @@ data "template_file" "user_data" {
 ## Creates autoscaling cluster
 data "aws_ami" "ecs_ami" {
   most_recent = true
+  owners      = ["amazon"]
 
   filter {
     name   = "architecture"
@@ -31,11 +30,6 @@ data "aws_ami" "ecs_ami" {
   filter {
     name   = "name"
     values = ["amzn-ami-*-amazon-ecs-optimized"]
-  }
-
-  filter {
-    name   = "owner-alias"
-    values = ["amazon"]
   }
 
   filter {
@@ -50,7 +44,7 @@ data "aws_ami" "ecs_ami" {
 }
 
 module "cluster" {
-  source = "github.com/unifio/terraform-aws-asg?ref=v0.3.1//group"
+  source = "github.com/unifio/terraform-aws-asg?ref=v0.3.7//group"
 
   # Resource tags
   stack_item_fullname = "${var.stack_item_fullname}"

--- a/examples/prereqs/main.tf
+++ b/examples/prereqs/main.tf
@@ -7,7 +7,7 @@ provider "aws" {
 
 ## Configures base VPC
 module "vpc_base" {
-  source = "github.com/unifio/terraform-aws-vpc?ref=v0.3.3//base"
+  source = "github.com/unifio/terraform-aws-vpc?ref=v0.4.0//base"
 
   enable_dns          = "true"
   stack_item_fullname = "${var.stack_item_fullname}"
@@ -17,7 +17,7 @@ module "vpc_base" {
 
 ## Configures VPC availabilty zones
 module "vpc_az" {
-  source = "github.com/unifio/terraform-aws-vpc?ref=v0.3.3//az"
+  source = "github.com/unifio/terraform-aws-vpc?ref=v0.4.0//az"
 
   azs_provisioned     = 2
   lans_per_az         = 0


### PR DESCRIPTION
* Removed use of current filter in aws region data source [#7]
* Added required owners argument to aws_ami data source [#8]
* Updated [terraform-aws-asg to v0.3.7](https://github.com/unifio/terraform-aws-asg/releases/tag/v0.3.7)
* Updated [terraform-aws-vpc to v0.4.0](https://github.com/unifio/terraform-aws-vpc/releases/tag/v0.4.0)
* Updated unifio/ci container to 3.0.622-ruby-2.5.3